### PR TITLE
Drop support for armhf and armv7

### DIFF
--- a/cloudpub-canary/build.yaml
+++ b/cloudpub-canary/build.yaml
@@ -1,8 +1,6 @@
 build_from:
   aarch64: ghcr.io/hassio-addons/debian-base:7.8.3
   amd64: ghcr.io/hassio-addons/debian-base:7.8.3
-  armhf: ghcr.io/hassio-addons/debian-base:7.8.3
-  armv7: ghcr.io/hassio-addons/debian-base:7.8.3
   i386: ghcr.io/hassio-addons/debian-base:7.8.3
 codenotary:
   base_image: codenotary@frenck.dev

--- a/cloudpub-canary/config.yaml
+++ b/cloudpub-canary/config.yaml
@@ -9,8 +9,6 @@ boot: auto
 arch:
   - aarch64
   - amd64
-  - armhf
-  - armv7
   - i386
 advanced: false
 stage: experimental

--- a/cloudpub/config.json
+++ b/cloudpub/config.json
@@ -10,8 +10,6 @@
   "arch": [
     "aarch64",
     "amd64",
-    "armhf",
-    "armv7",
     "i386"
   ],
   "image": "mansmarthome.cr.cloud.ru/black-roland/hassio-addon-cloudpub/{arch}",


### PR DESCRIPTION
Since 32-bit architectures [are going to be deprecated soon](https://www.home-assistant.io/blog/2025/05/22/deprecating-core-and-supervised-installation-methods-and-32-bit-systems/).

Although, Cloud.ru stats shows that i386 is still used so let's keep it for now.