### PR TITLE
Revert "Update dependency clo to v3.2.2"

### DIFF
--- a/cloudpub-canary/Dockerfile
+++ b/cloudpub-canary/Dockerfile
@@ -8,7 +8,7 @@ FROM $BUILD_FROM
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG BUILD_ARCH=amd64
-ARG CLO_VERSION="3.2.2"
+ARG CLO_VERSION="3.2.0"
 
 RUN \
     if [ "${BUILD_ARCH}" = "aarch64" ]; then CLO_ARCH="aarch64"; \

--- a/cloudpub-canary/config.yaml
+++ b/cloudpub-canary/config.yaml
@@ -1,6 +1,6 @@
 name: CloudPub Client (Canary)
 slug: cloudpub-canary
-version: 3.2.2-1
+version: 3.2.0-1
 description: Тестовая версия дополнения
 url: https://github.com/black-roland/hassio-addon-cloudpub
 init: false


### PR DESCRIPTION
Latest `clo` identifies as `cloudpub-client 2.4.5-20260711101220-stable (cloudpub.ru)`. That causes constant update warning:

> Доступна новая версия: 3.2.0. Выполните команду `clo upgrade` для обновления.

Reverts black-roland/hassio-addon-cloudpub#73.